### PR TITLE
弾の発射方向および寿命の設定を実装

### DIFF
--- a/data/discgun/functions/entity/disc/hit_wall.mcfunction
+++ b/data/discgun/functions/entity/disc/hit_wall.mcfunction
@@ -1,5 +1,5 @@
-# 200tick後にバウンドした場合は砕け散る
-    execute if score @s D.Gun_Time matches 200.. run function discgun:entity/disc/death
+# 生存時間を超えた後にバウンドした場合は砕け散る
+    execute if score @s D.Gun_Time >= @s D.Gun_Life run function discgun:entity/disc/death
 
 # カンッ
     playsound minecraft:block.chain.break player @a ~ ~ ~ 1 1.5

--- a/data/discgun/functions/entity/disc/init.mcfunction
+++ b/data/discgun/functions/entity/disc/init.mcfunction
@@ -1,6 +1,6 @@
 
-# 空から降りてくる
-    tp @s ~ ~-200 ~ 
+# 空から降りてくる&向き補正
+    tp @s ~ ~-200 ~ ~ ~
 
 # ブーメランのID
     scoreboard players add $Mo.ID_Core D.Gun_Mo.ID 1
@@ -15,10 +15,11 @@
     execute at @s positioned ~ ~0.85 ~ run scoreboard players operation @e[type=area_effect_cloud,tag=D.Gun_Rotater,tag=D.Gun_Init,limit=1,sort=nearest] D.Gun_Mo.ID = @s D.Gun_Mo.ID
     execute at @s run scoreboard players operation @e[type=armor_stand,tag=D.Gun_Model,tag=!D.Gun_Model_Already,limit=1,sort=nearest] D.Gun_Mo.ID = @s D.Gun_Mo.ID
     execute at @s run data modify entity @s ArmorItems[0].tag.OwnerUUID set from entity @p[tag=Chuz.This] UUID
+    scoreboard players operation @s D.Gun_Life = _ D.Gun_Life
 
-# ローテーターの向きをプレイヤーの向きに
-    execute at @s positioned ~ ~0.85 ~ run execute store result entity @e[tag=D.Gun_Rotater,tag=D.Gun_Init,limit=1,sort=nearest] Rotation[0] float 1 run data get entity @p[tag=Chuz.This] Rotation[0]
-    execute at @s positioned ~ ~0.85 ~ run execute store result entity @e[tag=D.Gun_Rotater,tag=D.Gun_Init,limit=1,sort=nearest] Rotation[1] float 1 run data get entity @p[tag=Chuz.This] Rotation[1]
+# ローテーターの向きを実行時の向きに
+    execute at @s positioned ~ ~0.85 ~ run execute store result entity @e[tag=D.Gun_Rotater,tag=D.Gun_Init,limit=1,sort=nearest] Rotation[0] float 1 run data get entity @s Rotation[0]
+    execute at @s positioned ~ ~0.85 ~ run execute store result entity @e[tag=D.Gun_Rotater,tag=D.Gun_Init,limit=1,sort=nearest] Rotation[1] float 1 run data get entity @s Rotation[1]
     tag @e[tag=D.Gun_Rotater,limit=1,sort=nearest] remove D.Gun_Init
 
 # 初期モーション取得

--- a/data/discgun/functions/entity/disc_charged/init.mcfunction
+++ b/data/discgun/functions/entity/disc_charged/init.mcfunction
@@ -1,6 +1,6 @@
 
-# 空から降りてくる
-    tp @s ~ ~-200 ~ 
+# 空から降りてくる&向き補正
+    tp @s ~ ~-200 ~ ~ ~
 
 # ブーメランのID
     scoreboard players add $Mo.ID_Core D.Gun_Mo.ID 1
@@ -15,10 +15,11 @@
     execute at @s positioned ~ ~0.85 ~ run scoreboard players operation @e[type=area_effect_cloud,tag=D.Gun_Rotater,tag=D.Gun_Init,limit=1,sort=nearest] D.Gun_Mo.ID = @s D.Gun_Mo.ID
     execute at @s run scoreboard players operation @e[type=armor_stand,tag=D.Gun_Model,tag=!D.Gun_Model_Already,limit=1,sort=nearest] D.Gun_Mo.ID = @s D.Gun_Mo.ID
     execute at @s run data modify entity @s ArmorItems[0].tag.OwnerUUID set from entity @p[tag=Chuz.This] UUID
+    scoreboard players operation @s D.Gun_Life = _ D.Gun_Life
 
-# ローテーターの向きをプレイヤーの向きに
-    execute at @s positioned ~ ~0.85 ~ run execute store result entity @e[tag=D.Gun_Rotater,tag=D.Gun_Init,limit=1,sort=nearest] Rotation[0] float 1 run data get entity @p[tag=Chuz.This] Rotation[0]
-    execute at @s positioned ~ ~0.85 ~ run execute store result entity @e[tag=D.Gun_Rotater,tag=D.Gun_Init,limit=1,sort=nearest] Rotation[1] float 1 run data get entity @p[tag=Chuz.This] Rotation[1]
+# ローテーターの向きを実行時の向きに
+    execute at @s positioned ~ ~0.85 ~ run execute store result entity @e[tag=D.Gun_Rotater,tag=D.Gun_Init,limit=1,sort=nearest] Rotation[0] float 1 run data get entity @s Rotation[0]
+    execute at @s positioned ~ ~0.85 ~ run execute store result entity @e[tag=D.Gun_Rotater,tag=D.Gun_Init,limit=1,sort=nearest] Rotation[1] float 1 run data get entity @s Rotation[1]
     tag @e[tag=D.Gun_Rotater,limit=1,sort=nearest] remove D.Gun_Init
 
 # 初期モーション取得

--- a/data/discgun/functions/entity/disc_charged_2/init.mcfunction
+++ b/data/discgun/functions/entity/disc_charged_2/init.mcfunction
@@ -1,6 +1,6 @@
 
-# 空から降りてくる
-    tp @s ~ ~-200 ~ 
+# 空から降りてくる&向き補正
+    tp @s ~ ~-200 ~ ~ ~
 
 # ブーメランのID
     scoreboard players add $Mo.ID_Core D.Gun_Mo.ID 1
@@ -15,10 +15,11 @@
     execute at @s positioned ~ ~0.85 ~ run scoreboard players operation @e[type=area_effect_cloud,tag=D.Gun_Rotater,tag=D.Gun_Init,limit=1,sort=nearest] D.Gun_Mo.ID = @s D.Gun_Mo.ID
     execute at @s run scoreboard players operation @e[type=armor_stand,tag=D.Gun_Model,tag=!D.Gun_Model_Already,limit=1,sort=nearest] D.Gun_Mo.ID = @s D.Gun_Mo.ID
     execute at @s run data modify entity @s ArmorItems[0].tag.OwnerUUID set from entity @p[tag=Chuz.This] UUID
+    scoreboard players operation @s D.Gun_Life = _ D.Gun_Life
 
-# ローテーターの向きをプレイヤーの向きに
-    execute at @s positioned ~ ~0.85 ~ run execute store result entity @e[tag=D.Gun_Rotater,tag=D.Gun_Init,limit=1,sort=nearest] Rotation[0] float 1 run data get entity @p[tag=Chuz.This] Rotation[0]
-    execute at @s positioned ~ ~0.85 ~ run execute store result entity @e[tag=D.Gun_Rotater,tag=D.Gun_Init,limit=1,sort=nearest] Rotation[1] float 1 run data get entity @p[tag=Chuz.This] Rotation[1]
+# ローテーターの向きを実行時の向きに
+    execute at @s positioned ~ ~0.85 ~ run execute store result entity @e[tag=D.Gun_Rotater,tag=D.Gun_Init,limit=1,sort=nearest] Rotation[0] float 1 run data get entity @s Rotation[0]
+    execute at @s positioned ~ ~0.85 ~ run execute store result entity @e[tag=D.Gun_Rotater,tag=D.Gun_Init,limit=1,sort=nearest] Rotation[1] float 1 run data get entity @s Rotation[1]
     tag @e[tag=D.Gun_Rotater,limit=1,sort=nearest] remove D.Gun_Init
 
 # 初期モーション取得

--- a/data/discgun/functions/item/discgun/shot.mcfunction
+++ b/data/discgun/functions/item/discgun/shot.mcfunction
@@ -13,10 +13,10 @@
     execute anchored eyes run particle minecraft:crit ^-0.35 ^-0.25 ^1 0 0 0 0.35 10 normal @s
 
 # 弾を召喚
-    execute unless score @s D.Gun_ShotPos matches 1.. anchored eyes rotated ~ 0 run summon pig ^0.25 ^199.5 ^ {Silent:1b,Invulnerable:1b,Team:"No_Collision",PortalCooldown:2147483647,DeathTime:19,DeathLootTable:"miencraft:empty",Age:-2147483648,Tags:["D.Gun_DiscInit","D.Gun_NoHit","D.Gun_Common"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,Tags:["D.Gun_Rotater","D.Gun_Init"]}],ArmorItems:[{id:"minecraft:knowledge_book",Count:1b},{},{},{}],ArmorDropChances:[0.000F,0.085F,0.085F,0.085F],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:2147483647,ShowParticles:0b}]}
+    execute unless score @s D.Gun_ShotPos matches 1.. anchored eyes rotated ~ 0 run summon pig ^0.25 ^199.5 ^ {Silent:1b,Invulnerable:1b,Team:"No_Collision",PortalCooldown:2147483647,DeathTime:19,DeathLootTable:"minecraft:empty",Age:-2147483648,Tags:["D.Gun_DiscInit","D.Gun_NoHit","D.Gun_Common"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,Tags:["D.Gun_Rotater","D.Gun_Init"]}],ArmorItems:[{id:"minecraft:knowledge_book",Count:1b},{},{},{}],ArmorDropChances:[0.000F,0.085F,0.085F,0.085F],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:2147483647,ShowParticles:0b}]}
     execute unless score @s D.Gun_ShotPos matches 1.. rotated ~ 0 anchored eyes run summon armor_stand ^0.25 ^-1.5 ^ {Small:1b,Invisible:1b,Tags:["D.Gun_Model"],PortalCooldown:2147483647,Pose:{Head:[0.1f,0.1f,0.1f]},DisabledSlots:4144959,ArmorItems:[{},{},{},{id:"minecraft:warped_fungus_on_a_stick",Count:1b,tag:{CustomModelData:7}}]}
 
-    execute if score @s D.Gun_ShotPos matches 1.. anchored eyes rotated ~ 0 run summon pig ^-0.25 ^199.7 ^ {Silent:1b,Invulnerable:1b,Team:"No_Collision",PortalCooldown:2147483647,DeathTime:19,DeathLootTable:"miencraft:empty",Age:-2147483648,Tags:["D.Gun_DiscInit","D.Gun_NoHit","D.Gun_Common"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,Tags:["D.Gun_Rotater","D.Gun_Init"]}],ArmorItems:[{id:"minecraft:knowledge_book",Count:1b},{},{},{}],ArmorDropChances:[0.000F,0.085F,0.085F,0.085F],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:2147483647,ShowParticles:0b}]}
+    execute if score @s D.Gun_ShotPos matches 1.. anchored eyes rotated ~ 0 run summon pig ^-0.25 ^199.7 ^ {Silent:1b,Invulnerable:1b,Team:"No_Collision",PortalCooldown:2147483647,DeathTime:19,DeathLootTable:"minecraft:empty",Age:-2147483648,Tags:["D.Gun_DiscInit","D.Gun_NoHit","D.Gun_Common"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,Tags:["D.Gun_Rotater","D.Gun_Init"]}],ArmorItems:[{id:"minecraft:knowledge_book",Count:1b},{},{},{}],ArmorDropChances:[0.000F,0.085F,0.085F,0.085F],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:2147483647,ShowParticles:0b}]}
     execute if score @s D.Gun_ShotPos matches 1.. rotated ~ 0 anchored eyes run summon armor_stand ^-0.25 ^-1.5 ^ {Small:1b,Invisible:1b,Tags:["D.Gun_Model"],PortalCooldown:2147483647,Pose:{Head:[0.1f,0.1f,0.1f]},DisabledSlots:4144959,ArmorItems:[{},{},{},{id:"minecraft:warped_fungus_on_a_stick",Count:1b,tag:{CustomModelData:7}}]}
 
 # 次に撃つ位置が変わる  
@@ -24,7 +24,9 @@
     scoreboard players reset @s[scores={D.Gun_ShotPos=2..}] D.Gun_ShotPos
 
 # INIT実行
-    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s run function discgun:entity/disc/init
+    scoreboard players set _ D.Gun_Life 200
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] run function discgun:entity/disc/init
+    scoreboard players reset _ D.Gun_Life
 
 # 弾丸消費
     execute in overworld run function discgun:item/consume_ammo

--- a/data/discgun/functions/item/discgun/shot_charged.mcfunction
+++ b/data/discgun/functions/item/discgun/shot_charged.mcfunction
@@ -14,11 +14,13 @@
     execute positioned ~ ~1.35 ~ run particle minecraft:crit ^-0.35 ^ ^1 0 0 0 0.35 10 normal @s
 
 # 弾を召喚
-    execute anchored eyes rotated ~ 0 run summon pig ^ ^199.5 ^ {Silent:1b,Invulnerable:1b,Team:"No_Collision",PortalCooldown:2147483647,DeathTime:19,DeathLootTable:"miencraft:empty",Age:-2147483648,Tags:["D.Gun_DiscInit","D.Gun_NoHit","D.Gun_Common"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,Tags:["D.Gun_Rotater","D.Gun_Init"]}],ArmorItems:[{id:"minecraft:knowledge_book",Count:1b},{},{},{}],ArmorDropChances:[0.000F,0.085F,0.085F,0.085F],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:2147483647,ShowParticles:0b}]}
+    execute anchored eyes rotated ~ 0 run summon pig ^ ^199.5 ^ {Silent:1b,Invulnerable:1b,Team:"No_Collision",PortalCooldown:2147483647,DeathTime:19,DeathLootTable:"minecraft:empty",Age:-2147483648,Tags:["D.Gun_DiscInit","D.Gun_NoHit","D.Gun_Common"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,Tags:["D.Gun_Rotater","D.Gun_Init"]}],ArmorItems:[{id:"minecraft:knowledge_book",Count:1b},{},{},{}],ArmorDropChances:[0.000F,0.085F,0.085F,0.085F],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:2147483647,ShowParticles:0b}]}
     execute rotated ~ 0 anchored eyes run summon armor_stand ^ ^-1.5 ^ {Small:1b,Invisible:1b,Tags:["D.Gun_Model"],PortalCooldown:2147483647,Pose:{Head:[0.1f,0.1f,0.1f]},DisabledSlots:4144959,ArmorItems:[{},{},{},{id:"minecraft:warped_fungus_on_a_stick",Count:1b,tag:{CustomModelData:8}}]}
 
 # INIT実行
-    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s run function discgun:entity/disc_charged/init
+    scoreboard players set _ D.Gun_Life 200
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] run function discgun:entity/disc_charged/init
+    scoreboard players reset _ D.Gun_Life
 
 # 弾丸消費
     execute in overworld run function discgun:item/consume_ammo

--- a/data/discgun/functions/item/discgun/shot_charged_2.mcfunction
+++ b/data/discgun/functions/item/discgun/shot_charged_2.mcfunction
@@ -14,11 +14,13 @@
     execute positioned ~ ~1.35 ~ run particle minecraft:crit ^-0.35 ^ ^1 0 0 0 0.35 10 normal @s
 
 # 弾を召喚
-    execute anchored eyes rotated ~ 0 run summon pig ^ ^199.5 ^ {Silent:1b,Invulnerable:1b,Team:"No_Collision",PortalCooldown:2147483647,DeathTime:19,DeathLootTable:"miencraft:empty",Age:-2147483648,Tags:["D.Gun_DiscInit","D.Gun_NoHit","D.Gun_Common"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,Tags:["D.Gun_Rotater","D.Gun_Init"]}],ArmorItems:[{id:"minecraft:knowledge_book",Count:1b},{},{},{}],ArmorDropChances:[0.000F,0.085F,0.085F,0.085F],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:2147483647,ShowParticles:0b}]}
+    execute anchored eyes rotated ~ 0 run summon pig ^ ^199.5 ^ {Silent:1b,Invulnerable:1b,Team:"No_Collision",PortalCooldown:2147483647,DeathTime:19,DeathLootTable:"minecraft:empty",Age:-2147483648,Tags:["D.Gun_DiscInit","D.Gun_NoHit","D.Gun_Common"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,Tags:["D.Gun_Rotater","D.Gun_Init"]}],ArmorItems:[{id:"minecraft:knowledge_book",Count:1b},{},{},{}],ArmorDropChances:[0.000F,0.085F,0.085F,0.085F],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:2147483647,ShowParticles:0b}]}
     execute rotated ~ 0 anchored eyes run summon armor_stand ^ ^-1.5 ^ {Small:1b,Invisible:1b,Tags:["D.Gun_Model"],PortalCooldown:2147483647,Pose:{Head:[0.1f,0.1f,0.1f]},DisabledSlots:4144959,ArmorItems:[{},{},{},{id:"minecraft:warped_fungus_on_a_stick",Count:1b,tag:{CustomModelData:9}}]}
 
 # INIT実行
-    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s run function discgun:entity/disc_charged_2/init
+    scoreboard players set _ D.Gun_Life 200
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] run function discgun:entity/disc_charged_2/init
+    scoreboard players reset _ D.Gun_Life
 
 # 弾丸消費
     execute in overworld run function discgun:item/consume_ammo

--- a/data/discgun/functions/item/super_discgun/shot.mcfunction
+++ b/data/discgun/functions/item/super_discgun/shot.mcfunction
@@ -10,11 +10,18 @@
     tag @s add Chuz.This
 
 # 弾を召喚
+    scoreboard players set _ D.Gun_Life 100
     execute positioned ^ ^ ^ run function discgun:item/super_discgun/shot_disc
-    execute positioned ^0.5 ^ ^ run function discgun:item/super_discgun/shot_disc
-    execute positioned ^-0.5 ^ ^ run function discgun:item/super_discgun/shot_disc
-    execute positioned ^1 ^ ^ run function discgun:item/super_discgun/shot_disc
-    execute positioned ^-1 ^ ^ run function discgun:item/super_discgun/shot_disc
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] run function discgun:entity/disc/init
+    execute positioned ^0.1 ^ ^ run function discgun:item/super_discgun/shot_disc
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^0.087489 ^ ^1 run function discgun:entity/disc/init
+    execute positioned ^-0.1 ^ ^ run function discgun:item/super_discgun/shot_disc
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^-0.087489 ^ ^1 run function discgun:entity/disc/init
+    execute positioned ^0.2 ^ ^ run function discgun:item/super_discgun/shot_disc
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^0.176327 ^ ^1 run function discgun:entity/disc/init
+    execute positioned ^-0.2 ^ ^ run function discgun:item/super_discgun/shot_disc
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^-0.176327 ^ ^1 run function discgun:entity/disc/init
+    scoreboard players reset _ D.Gun_Life
 
 
 # 弾丸消費

--- a/data/discgun/functions/item/super_discgun/shot.mcfunction
+++ b/data/discgun/functions/item/super_discgun/shot.mcfunction
@@ -13,13 +13,13 @@
     scoreboard players set _ D.Gun_Life 100
     execute positioned ^ ^ ^ run function discgun:item/super_discgun/shot_disc
     execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] run function discgun:entity/disc/init
-    execute positioned ^0.1 ^ ^ run function discgun:item/super_discgun/shot_disc
+    execute positioned ^0.5 ^ ^ run function discgun:item/super_discgun/shot_disc
     execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^0.087489 ^ ^1 run function discgun:entity/disc/init
-    execute positioned ^-0.1 ^ ^ run function discgun:item/super_discgun/shot_disc
+    execute positioned ^-0.5 ^ ^ run function discgun:item/super_discgun/shot_disc
     execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^-0.087489 ^ ^1 run function discgun:entity/disc/init
-    execute positioned ^0.2 ^ ^ run function discgun:item/super_discgun/shot_disc
+    execute positioned ^1 ^ ^ run function discgun:item/super_discgun/shot_disc
     execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^0.176327 ^ ^1 run function discgun:entity/disc/init
-    execute positioned ^-0.2 ^ ^ run function discgun:item/super_discgun/shot_disc
+    execute positioned ^-1 ^ ^ run function discgun:item/super_discgun/shot_disc
     execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^-0.176327 ^ ^1 run function discgun:entity/disc/init
     scoreboard players reset _ D.Gun_Life
 

--- a/data/discgun/functions/item/super_discgun/shot_charged.mcfunction
+++ b/data/discgun/functions/item/super_discgun/shot_charged.mcfunction
@@ -14,13 +14,13 @@
     scoreboard players set _ D.Gun_Life 100
     execute positioned ^ ^ ^ run function discgun:item/super_discgun/shot_disc_charged
     execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] run function discgun:entity/disc_charged/init
-    execute positioned ^0.1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
+    execute positioned ^0.5 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
     execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^0.087489 ^ ^1 run function discgun:entity/disc_charged/init
-    execute positioned ^-0.1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
+    execute positioned ^-0.5 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
     execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^-0.087489 ^ ^1 run function discgun:entity/disc_charged/init
-    execute positioned ^0.2 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
+    execute positioned ^1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
     execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^0.176327 ^ ^1 run function discgun:entity/disc_charged/init
-    execute positioned ^-0.2 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
+    execute positioned ^-1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
     execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^-0.176327 ^ ^1 run function discgun:entity/disc_charged/init
     scoreboard players reset _ D.Gun_Life
 

--- a/data/discgun/functions/item/super_discgun/shot_charged.mcfunction
+++ b/data/discgun/functions/item/super_discgun/shot_charged.mcfunction
@@ -11,11 +11,18 @@
     tag @s add Chuz.This
 
 # 弾を召喚
+    scoreboard players set _ D.Gun_Life 100
     execute positioned ^ ^ ^ run function discgun:item/super_discgun/shot_disc_charged
-    execute positioned ^0.5 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
-    execute positioned ^-0.5 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
-    execute positioned ^1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
-    execute positioned ^-1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] run function discgun:entity/disc_charged/init
+    execute positioned ^0.1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^0.087489 ^ ^1 run function discgun:entity/disc_charged/init
+    execute positioned ^-0.1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^-0.087489 ^ ^1 run function discgun:entity/disc_charged/init
+    execute positioned ^0.2 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^0.176327 ^ ^1 run function discgun:entity/disc_charged/init
+    execute positioned ^-0.2 ^ ^ run function discgun:item/super_discgun/shot_disc_charged
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^-0.176327 ^ ^1 run function discgun:entity/disc_charged/init
+    scoreboard players reset _ D.Gun_Life
 
 # 弾丸消費
     execute in overworld run function discgun:item/consume_ammo

--- a/data/discgun/functions/item/super_discgun/shot_charged_2.mcfunction
+++ b/data/discgun/functions/item/super_discgun/shot_charged_2.mcfunction
@@ -14,13 +14,13 @@
     scoreboard players set _ D.Gun_Life 100
     execute positioned ^ ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
     execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] run function discgun:entity/disc_charged_2/init
-    execute positioned ^0.1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
+    execute positioned ^0.5 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
     execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^0.087489 ^ ^1 run function discgun:entity/disc_charged_2/init
-    execute positioned ^-0.1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
+    execute positioned ^-0.5 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
     execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^-0.087489 ^ ^1 run function discgun:entity/disc_charged_2/init
-    execute positioned ^0.2 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
+    execute positioned ^1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
     execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^0.176327 ^ ^1 run function discgun:entity/disc_charged_2/init
-    execute positioned ^-0.2 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
+    execute positioned ^-1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
     execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^-0.176327 ^ ^1 run function discgun:entity/disc_charged_2/init
     scoreboard players reset _ D.Gun_Life
 

--- a/data/discgun/functions/item/super_discgun/shot_charged_2.mcfunction
+++ b/data/discgun/functions/item/super_discgun/shot_charged_2.mcfunction
@@ -11,11 +11,18 @@
     tag @s add Chuz.This
 
 # 弾を召喚
+    scoreboard players set _ D.Gun_Life 100
     execute positioned ^ ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
-    execute positioned ^0.5 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
-    execute positioned ^-0.5 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
-    execute positioned ^1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
-    execute positioned ^-1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] run function discgun:entity/disc_charged_2/init
+    execute positioned ^0.1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^0.087489 ^ ^1 run function discgun:entity/disc_charged_2/init
+    execute positioned ^-0.1 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^-0.087489 ^ ^1 run function discgun:entity/disc_charged_2/init
+    execute positioned ^0.2 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^0.176327 ^ ^1 run function discgun:entity/disc_charged_2/init
+    execute positioned ^-0.2 ^ ^ run function discgun:item/super_discgun/shot_disc_charged_2
+    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s rotated as @p[tag=Chuz.This] facing ^-0.176327 ^ ^1 run function discgun:entity/disc_charged_2/init
+    scoreboard players reset _ D.Gun_Life
 
 # 弾丸消費
     execute in overworld run function discgun:item/consume_ammo

--- a/data/discgun/functions/item/super_discgun/shot_disc.mcfunction
+++ b/data/discgun/functions/item/super_discgun/shot_disc.mcfunction
@@ -1,6 +1,5 @@
 
 # 弾を召喚
-    execute anchored eyes rotated ~ 0 run summon pig ^ ^199.5 ^ {Silent:1b,Invulnerable:1b,Team:"No_Collision",PortalCooldown:2147483647,DeathTime:19,DeathLootTable:"miencraft:empty",Age:-2147483648,Tags:["D.Gun_DiscInit","D.Gun_NoHit","D.Gun_Common"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,Tags:["D.Gun_Rotater","D.Gun_Init"]}],ArmorItems:[{id:"minecraft:knowledge_book",Count:1b},{},{},{}],ArmorDropChances:[0.000F,0.085F,0.085F,0.085F],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:2147483647,ShowParticles:0b}]}
+    execute anchored eyes rotated ~ 0 run summon pig ^ ^199.5 ^ {Silent:1b,Invulnerable:1b,Team:"No_Collision",PortalCooldown:2147483647,DeathTime:19,DeathLootTable:"minecraft:empty",Age:-2147483648,Tags:["D.Gun_DiscInit","D.Gun_NoHit","D.Gun_Common"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,Tags:["D.Gun_Rotater","D.Gun_Init"]}],ArmorItems:[{id:"minecraft:knowledge_book",Count:1b},{},{},{}],ArmorDropChances:[0.000F,0.085F,0.085F,0.085F],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:2147483647,ShowParticles:0b}]}
     execute rotated ~ 0 anchored eyes run summon armor_stand ^ ^-1.5 ^ {Small:1b,Invisible:1b,Tags:["D.Gun_Model"],PortalCooldown:2147483647,Pose:{Head:[0.1f,0.1f,0.1f]},DisabledSlots:4144959,ArmorItems:[{},{},{},{id:"minecraft:warped_fungus_on_a_stick",Count:1b,tag:{CustomModelData:7}}]}
-    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s run function discgun:entity/disc/init
 

--- a/data/discgun/functions/item/super_discgun/shot_disc_charged.mcfunction
+++ b/data/discgun/functions/item/super_discgun/shot_disc_charged.mcfunction
@@ -1,6 +1,5 @@
 
 # 弾を召喚
-    execute anchored eyes rotated ~ 0 run summon pig ^ ^199.5 ^ {Silent:1b,Invulnerable:1b,Team:"No_Collision",PortalCooldown:2147483647,DeathTime:19,DeathLootTable:"miencraft:empty",Age:-2147483648,Tags:["D.Gun_DiscInit","D.Gun_NoHit","D.Gun_Common"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,Tags:["D.Gun_Rotater","D.Gun_Init"]}],ArmorItems:[{id:"minecraft:knowledge_book",Count:1b},{},{},{}],ArmorDropChances:[0.000F,0.085F,0.085F,0.085F],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:2147483647,ShowParticles:0b}]}
+    execute anchored eyes rotated ~ 0 run summon pig ^ ^199.5 ^ {Silent:1b,Invulnerable:1b,Team:"No_Collision",PortalCooldown:2147483647,DeathTime:19,DeathLootTable:"minecraft:empty",Age:-2147483648,Tags:["D.Gun_DiscInit","D.Gun_NoHit","D.Gun_Common"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,Tags:["D.Gun_Rotater","D.Gun_Init"]}],ArmorItems:[{id:"minecraft:knowledge_book",Count:1b},{},{},{}],ArmorDropChances:[0.000F,0.085F,0.085F,0.085F],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:2147483647,ShowParticles:0b}]}
     execute rotated ~ 0 anchored eyes run summon armor_stand ^ ^-1.5 ^ {Small:1b,Invisible:1b,Tags:["D.Gun_Model"],PortalCooldown:2147483647,Pose:{Head:[0.1f,0.1f,0.1f]},DisabledSlots:4144959,ArmorItems:[{},{},{},{id:"minecraft:warped_fungus_on_a_stick",Count:1b,tag:{CustomModelData:8}}]}
-    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s run function discgun:entity/disc_charged/init
 

--- a/data/discgun/functions/item/super_discgun/shot_disc_charged_2.mcfunction
+++ b/data/discgun/functions/item/super_discgun/shot_disc_charged_2.mcfunction
@@ -1,6 +1,5 @@
 
 # 弾を召喚
-    execute anchored eyes rotated ~ 0 run summon pig ^ ^199.5 ^ {Silent:1b,Invulnerable:1b,Team:"No_Collision",PortalCooldown:2147483647,DeathTime:19,DeathLootTable:"miencraft:empty",Age:-2147483648,Tags:["D.Gun_DiscInit","D.Gun_NoHit","D.Gun_Common"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,Tags:["D.Gun_Rotater","D.Gun_Init"]}],ArmorItems:[{id:"minecraft:knowledge_book",Count:1b},{},{},{}],ArmorDropChances:[0.000F,0.085F,0.085F,0.085F],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:2147483647,ShowParticles:0b}]}
+    execute anchored eyes rotated ~ 0 run summon pig ^ ^199.5 ^ {Silent:1b,Invulnerable:1b,Team:"No_Collision",PortalCooldown:2147483647,DeathTime:19,DeathLootTable:"minecraft:empty",Age:-2147483648,Tags:["D.Gun_DiscInit","D.Gun_NoHit","D.Gun_Common"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,Tags:["D.Gun_Rotater","D.Gun_Init"]}],ArmorItems:[{id:"minecraft:knowledge_book",Count:1b},{},{},{}],ArmorDropChances:[0.000F,0.085F,0.085F,0.085F],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:2147483647,ShowParticles:0b}]}
     execute rotated ~ 0 anchored eyes run summon armor_stand ^ ^-1.5 ^ {Small:1b,Invisible:1b,Tags:["D.Gun_Model"],PortalCooldown:2147483647,Pose:{Head:[0.1f,0.1f,0.1f]},DisabledSlots:4144959,ArmorItems:[{},{},{},{id:"minecraft:warped_fungus_on_a_stick",Count:1b,tag:{CustomModelData:9}}]}
-    execute as @e[type=pig,tag=D.Gun_DiscInit,limit=1,sort=nearest] at @s run function discgun:entity/disc_charged_2/init
 

--- a/data/discgun/functions/load.mcfunction
+++ b/data/discgun/functions/load.mcfunction
@@ -4,6 +4,7 @@
     scoreboard objectives add D.Gun_Shot minecraft.used:minecraft.crossbow
     scoreboard objectives add D.Gun_Sneak minecraft.custom:minecraft.sneak_time
     scoreboard objectives add D.Gun_Time dummy
+    scoreboard objectives add D.Gun_Life dummy
     scoreboard objectives add D.Gun_Range dummy
     scoreboard objectives add D.Gun_Speed dummy
     scoreboard objectives add D.Gun_Temp dummy


### PR DESCRIPTION
弾の発射方向と弾の寿命を設定できるようにしました．

### 発射方向について
- "init実行時のrotation"を弾の向きとして設定します．
- Super Disc Gunは暫定的に0度，+-5度，+-10度で撃つようにしています．

### 寿命について
- 新しいscore"D.Gun_Life"を追加しました．
- init実行時，ダミーplayer"_"の"D.Gun_Life"のscoreを弾の寿命に設定します．
- Super Disc Gunは暫定的に100tickで消えるようにしています．